### PR TITLE
Fixes a couple of problems with "clear"

### DIFF
--- a/reprint/reprint.py
+++ b/reprint/reprint.py
@@ -198,16 +198,16 @@ class output:
                 else:
                     self.parent.refresh(int(time.time()*1000), forced=False)
 
-        def clear():
+        def clear(self):
             global is_atty
-            with self.lock:
-                if six.PY2:
-                    self[:] = []
-                elif six.PY3:
-                    super(output.SignalList, self).clear()
+            # with self.lock: In all places you call clear, you actually already have the lock
+            if six.PY2:
+                self[:] = []
+            elif six.PY3:
+                super(output.SignalList, self).clear()
 
-                if is_atty:
-                    self.parent.refresh(int(time.time()*1000), forced=False)
+            if is_atty:
+                self.parent.refresh(int(time.time()*1000), forced=False)
 
         def change(self, newlist):
             with self.lock:
@@ -281,10 +281,10 @@ class output:
 
         def clear(self):
             global is_atty
-            with self.lock:
-                super(output.SignalDict, self).clear()
-                if is_atty:
-                    self.parent.refresh(int(time.time()*1000), forced=False)
+            # with self.lock: In all places you call clear, you actually already have the lock
+            super(output.SignalDict, self).clear()
+            if is_atty:
+                self.parent.refresh(int(time.time()*1000), forced=False)
 
         def pop(self, *args, **kwargs):
             global is_atty


### PR DESCRIPTION
1) the list's `clear` function didn't take self as 1st parameter, so it complained

2) both `clear` functions tried to get the lock before doing anything, but in fact whenever they were called (in `change`) the lock had already been acquired, so we don't need it and in fact trying to get it again causes deadlock 

Fortunately these were small fixes and it works now!